### PR TITLE
Enable admin page with decap-cms content management

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -15,3 +15,14 @@ collections:
       - { name: date, label: Date, widget: datetime }
       - { name: title, label: Title }
       - { name: body, label: Body, widget: markdown }
+  - name: members
+    label: Members
+    folder: content/members
+    create: true
+    fields:
+      - { name: nome, label: Nome }
+      - { name: nomeCivil, label: NomeCivil }
+      - { name: curso, label: Curso }
+      - { name: madrinha, label: Madrinha }
+      - { name: instrumentos, label: Instrumentos }
+      - { name: foto, label: Foto }

--- a/config.yml
+++ b/config.yml
@@ -1,6 +1,6 @@
 backend:
   name: git-gateway
-  branch: main
+  branch: feature/admin-page
 
 media_folder: static/img
 public_folder: /img

--- a/config.yml
+++ b/config.yml
@@ -1,6 +1,6 @@
 backend:
   name: git-gateway
-  branch: feature/admin-page
+  branch: dev
 
 media_folder: static/img
 public_folder: /img

--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -5,3 +5,8 @@
  */
 
 // You can delete this file if you're not using it
+import { initNetlifyIdentity } from './src/netlify-identity';
+
+export const onClientEntry = () => {
+  initNetlifyIdentity();
+};

--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -1,12 +1,7 @@
-/**
- * Implement Gatsby's Browser APIs in this file.
- *
- * See: https://www.gatsbyjs.org/docs/browser-apis/
- */
+import netlifyIdentity from 'netlify-identity-widget';
 
-// You can delete this file if you're not using it
-import { initNetlifyIdentity } from './src/scripts/netlify-identity';
-
-export const onClientEntry = () => {
-  initNetlifyIdentity();
+export const onRouteUpdate = ({ location }) => {
+  if (location.pathname === '/admin/') {
+    netlifyIdentity.init();
+  }
 };

--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -5,7 +5,7 @@
  */
 
 // You can delete this file if you're not using it
-import { initNetlifyIdentity } from './src/netlify-identity';
+import { initNetlifyIdentity } from './src/scripts/netlify-identity';
 
 export const onClientEntry = () => {
   initNetlifyIdentity();

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "react-dom": "^18.3.1",
     "react-helmet": "^6.1.0",
     "react-icons": "^5.2.1",
-    "graphql": "^16.0.0"
+    "graphql": "^16.0.0",
+    "netlify-identity-widget": "^1.9.1"
   },
   "devDependencies": {
     "prettier": "^2.7.1"
@@ -33,7 +34,7 @@
     "build": "gatsby build",
     "develop": "gatsby develop",
     "format": "prettier --write \"**/*.{js,jsx,ts,tsx,json,md}\"",
-    "start": "yarm run dev",
+    "start": "yarn run dev",
     "serve": "gatsby serve",
     "clean": "gatsby clean"
   }

--- a/src/scripts/netlify-identity.js
+++ b/src/scripts/netlify-identity.js
@@ -1,0 +1,5 @@
+import netlifyIdentity from 'netlify-identity-widget';
+
+export const initNetlifyIdentity = () => {
+  netlifyIdentity.init();
+};

--- a/static/admin/index.html
+++ b/static/admin/index.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Content Manager</title>
+    <script src="https://identity.netlify.com/v1/netlify-identity-widget.js"></script>
 </head>
 <body>
 <!-- Include the script that builds the page and powers Netlify CMS -->


### PR DESCRIPTION
This pull request adds a new "Members" collection to the Decap CMS configuration and ensures that Netlify Identity is properly set up for authentication. The following changes have been made:

1. Add Members Collection:

    - Added a new "Members" collection to the [config.yml](https://github.com/ATUNAFE/Website/blob/feature/admin-page/config.yml) file.
    - Configured fields for the "Members" collection: nome, nomeCivil, curso, and madrinha.
2. Configure Netlify Identity:

    - Ensured that Netlify Identity is initialized only on the admin page.
    - Created Netlify Identity credentials
    - Configured GitHub to authorize Netlify changes 
3. Update Git Gateway Configuration:

    - Configured the backend to use Git Gateway with the dev branch.