### PR TITLE
Task56: Increase dimensions of "Edições" button on "Tudo Isto É Tuna" section on About Us page

### DIFF
--- a/src/components/about-us/tiet.js
+++ b/src/components/about-us/tiet.js
@@ -81,8 +81,10 @@ const TIET = ({ id }) => {
                                     className="custom-button"
                                     onClick={() => navigate(`${content.frontmatter.button.link}`)}
                                     style={{
-                                        height: "60px",
-                                        width: "120%"
+                                        height: "75px",
+                                        width: "80%",
+                                        minWidth: "150px",
+                                        maxWidth: "300px"
                                     }}
                                 >
                                     <h5 className="button-text" style={{ margin: 0 }}>{content.frontmatter.button.text}</h5>


### PR DESCRIPTION
- altura do botão ajustada de 60px para 75px
- largura ajustada para 80%
- minWidth e maxWidth adicionados para responsividade, 150px e 300px respetivamente
- em anexo, alguns prints dos testes em diferentes dimensões
<img width="1364" height="713" alt="browser" src="https://github.com/user-attachments/assets/fa4f24c4-3cf8-4c9c-ac47-fc9762abdc62" />
<img width="785" height="557" alt="smartphoneHorizontal" src="https://github.com/user-attachments/assets/719c5e0b-7f71-4240-80c4-89cc7b7d7963" />
<img width="680" height="632" alt="smartphoneVertical" src="https://github.com/user-attachments/assets/20ffd001-9152-49a8-a3f7-8e34f2abfeb9" />
<img width="803" height="626" alt="tabletHorizontal" src="https://github.com/user-attachments/assets/3e04b6b1-267d-43eb-ae2f-5339a5875fff" />
<img width="675" height="611" alt="tabletVertical" src="https://github.com/user-attachments/assets/96523287-4c4d-4350-9d61-705e8b1b4613" />
