### PR TITLE
Task67: Ensure collapsible components in"Reportório" section on "Música" page start closed

### DIFF
--- a/src/components/members/collapsible-section.js
+++ b/src/components/members/collapsible-section.js
@@ -2,8 +2,8 @@ import React, { useState } from "react";
 import { Card, Collapse, Row, Col } from "react-bootstrap";
 import { FaAngleUp, FaAngleDown } from "react-icons/fa";
 
-const CollapsibleSection = ({ title, color, backgroundColor, children, enabled = true }) => {
-    const [open, setOpen] = useState(true);
+const CollapsibleSection = ({ title, color, backgroundColor, children, enabled = true, defaultOpen = true}) => {
+    const [open, setOpen] = useState(defaultOpen);
 
     return (
         <Card className="mb-4" style={{ backgroundColor: "var(--mid-green)", border: "none" }}>

--- a/src/components/music/repertoire.js
+++ b/src/components/music/repertoire.js
@@ -80,7 +80,7 @@ const Repertoire = ({ id }) => {
                 <Row className="justify-content-start">
                     <Col xs={12} md={10} lg={8}>
                         {songs.map((song, index) =>
-                            <CollapsibleSection key={index} color={repertoire.frontmatter.color} backgroundColor={repertoire.frontmatter.backgroundColor} title={song.frontmatter.title.text} enabled={true}>
+                            <CollapsibleSection key={index} color={repertoire.frontmatter.color} backgroundColor={repertoire.frontmatter.backgroundColor} title={song.frontmatter.title.text} enabled={true} defaultOpen={false}>
                                 <p>{song.frontmatter.author}</p>
                                 <div style={{ textAlign: "justify" }}>
                                     <div dangerouslySetInnerHTML={{ __html: song.html }} />


### PR DESCRIPTION
- Em **collapsible-section.js** foi adicionado o prop _defaultOpen_ 
- Em **repertoire.js** os itens do reportório passam a usar _defaultOpen={false}_ para garantir que só aqui começam fechados, sem afetar as outras páginas que usam a secção colapsável